### PR TITLE
build: remove npm cleandb command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "npx cross-env NODE_ENV=local node --experimental-specifier-resolution=node --no-warnings ./src/server.js",
     "test": "npm run resetTestDb && npx cross-env NODE_ENV=test USE_SIMULATOR=true mocha --require @babel/register tests/**/*.spec.js --reporter spec --exit --timeout 300000",
     "release": "npx standard-version",
-    "cleandb": "rm -f ~/.chia/cadt/data.sqlite3",
+    "postinstall": "npm run requirements-check",
     "resetTestDb": "rm -f ./test.sqlite3 && rm -f ./testMirror.sqlite3",
     "resetMirrorDb": "npx sequelize-cli db:drop --env mirror",
     "prepare": "husky install",


### PR DESCRIPTION
The cleandb command had a hard-coded path that was inaccurate and is no longer used